### PR TITLE
Add more granular functions

### DIFF
--- a/android/src/main/java/com/skyward/NotificationManager/NotificationManager.java
+++ b/android/src/main/java/com/skyward/NotificationManager/NotificationManager.java
@@ -9,7 +9,6 @@ import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
-import android.app.Activity;
 
 
 public class NotificationManager implements ReactPackage {

--- a/android/src/main/java/com/skyward/NotificationManager/NotificationManagerModule.java
+++ b/android/src/main/java/com/skyward/NotificationManager/NotificationManagerModule.java
@@ -1,5 +1,10 @@
 package com.skyward.NotificationManager;
 
+import android.annotation.TargetApi;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.os.Build;
+
 import com.facebook.react.bridge.*;
 import com.facebook.react.bridge.Promise;
 import androidx.core.app.NotificationManagerCompat;
@@ -17,11 +22,103 @@ public class NotificationManagerModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void areNotificationsEnabled(final Promise promise) {
-      try {
-        Boolean areEnabled = NotificationManagerCompat.from(getReactApplicationContext()).areNotificationsEnabled();
-        promise.resolve(areEnabled);
-      } catch (Exception e) {
-        promise.reject(e.getMessage());
+    try {
+      Boolean areEnabled = NotificationManagerCompat.from(getReactApplicationContext()).areNotificationsEnabled();
+      promise.resolve(areEnabled);
+    } catch (Exception e) {
+      promise.reject(e);
+    }
+  }
+
+  @TargetApi(Build.VERSION_CODES.O)
+  private void retrieveNotificationChannelsOnAndroidOreo(Promise promise) {
+    NotificationManager notificationManager = getReactApplicationContext().getSystemService(NotificationManager.class);
+    if (notificationManager == null) {
+      promise.reject("no_notification_manager_service", "Could not retrieve Android NotificationManager service");
+      return;
+    }
+
+    try {
+      WritableArray notificationsChannels = Arguments.createArray();
+      for (NotificationChannel notificationChannel : notificationManager.getNotificationChannels()) {
+        WritableMap channel = Arguments.createMap();
+        channel.putString("id", notificationChannel.getId());
+        channel.putBoolean("isEnabled", notificationChannel.getImportance() != NotificationManager.IMPORTANCE_NONE);
+        channel.putBoolean("isBadgeEnabled", notificationChannel.canShowBadge());
+        channel.putBoolean("isSoundEnabled", notificationChannel.getSound() != null);
+        channel.putBoolean("shownInNotificationCenter", false);
+        channel.putBoolean("shownInLockScreen", notificationChannel.getLockscreenVisibility() > 0);
+        channel.putBoolean("shownAsHeadsupDisplay", notificationChannel.getImportance() >= NotificationManager.IMPORTANCE_HIGH);
+        notificationsChannels.pushMap(channel);
       }
+      promise.resolve(notificationsChannels);
+    } catch (Exception e) {
+      promise.reject(e);
+    }
+  }
+
+  @ReactMethod
+  public void retrieveNotificationChannels(Promise promise) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+      WritableArray notificationsChannels = Arguments.createArray();
+      promise.resolve(notificationsChannels);
+      return;
+    }
+
+    retrieveNotificationChannelsOnAndroidOreo(promise);
+  }
+
+  @ReactMethod
+  public void retrieveGlobalNotificationSettings(Promise promise) {
+    int importance;
+    try {
+      importance = NotificationManagerCompat.from(getReactApplicationContext()).getImportance();
+    } catch (Exception e) {
+      promise.reject(e);
+      return;
+    }
+
+    WritableMap settings = Arguments.createMap();
+    switch (importance) {
+      default:
+        promise.reject(new RuntimeException("unknown importance value: " + importance));
+        return;
+      case NotificationManagerCompat.IMPORTANCE_NONE:
+        settings.putBoolean("isEnabled", false);
+        settings.putBoolean("isBadgeEnabled", false);
+        settings.putBoolean("isSoundEnabled", false);
+        settings.putBoolean("shownInNotificationCenter", false);
+        settings.putBoolean("shownInLockScreen", false);
+        settings.putBoolean("shownAsHeadsupDisplay", false);
+        break;
+      case NotificationManagerCompat.IMPORTANCE_MIN:
+      case NotificationManagerCompat.IMPORTANCE_LOW:
+        settings.putBoolean("isEnabled", true);
+        settings.putBoolean("isBadgeEnabled", true);
+        settings.putBoolean("isSoundEnabled", false);
+        settings.putBoolean("shownInNotificationCenter", true);
+        settings.putBoolean("shownInLockScreen", true);
+        settings.putBoolean("shownAsHeadsupDisplay", false);
+        break;
+      case NotificationManagerCompat.IMPORTANCE_DEFAULT:
+      case NotificationManagerCompat.IMPORTANCE_UNSPECIFIED:
+        settings.putBoolean("isEnabled", true);
+        settings.putBoolean("isBadgeEnabled", true);
+        settings.putBoolean("isSoundEnabled", true);
+        settings.putBoolean("shownInNotificationCenter", true);
+        settings.putBoolean("shownInLockScreen", true);
+        settings.putBoolean("shownAsHeadsupDisplay", false);
+        break;
+      case NotificationManagerCompat.IMPORTANCE_HIGH:
+      case NotificationManagerCompat.IMPORTANCE_MAX:
+        settings.putBoolean("isEnabled", true);
+        settings.putBoolean("isBadgeEnabled", true);
+        settings.putBoolean("isSoundEnabled", true);
+        settings.putBoolean("shownInNotificationCenter", true);
+        settings.putBoolean("shownInLockScreen", true);
+        settings.putBoolean("shownAsHeadsupDisplay", true);
+        break;
+    }
+    promise.resolve(settings);
   }
 }

--- a/android/src/main/java/com/skyward/NotificationManager/NotificationManagerModule.java
+++ b/android/src/main/java/com/skyward/NotificationManager/NotificationManagerModule.java
@@ -1,45 +1,14 @@
 package com.skyward.NotificationManager;
 
-import com.facebook.react.uimanager.*;
 import com.facebook.react.bridge.*;
 import com.facebook.react.bridge.Promise;
-import com.facebook.systrace.Systrace;
-import com.facebook.systrace.SystraceMessage;
-import android.net.wifi.ScanResult;
-import android.net.wifi.WifiManager;
-import android.net.wifi.WifiConfiguration;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
-import android.content.Context;
-import android.content.Intent;
-import android.os.Bundle;
-import android.content.Context;
-import java.util.List;
-import com.facebook.systrace.Systrace;
-import com.facebook.systrace.SystraceMessage;
-
-// import com.facebook.react.LifecycleState;
-import com.facebook.react.ReactInstanceManager;
-import com.facebook.react.ReactRootView;
-import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
-import com.facebook.react.modules.core.DeviceEventManagerModule;
-import com.facebook.react.shell.MainReactPackage;
-import com.facebook.soloader.SoLoader;
-
-import java.util.Map;
-import java.util.HashMap;
-import java.util.concurrent.TimeUnit;
-
-import android.support.v4.app.NotificationManagerCompat;
+import androidx.core.app.NotificationManagerCompat;
 
 
 public class NotificationManagerModule extends ReactContextBaseJavaModule {
   public NotificationManagerModule(ReactApplicationContext reactContext) {
     super(reactContext);
   }
-
-  private static final String NOTIFICATION_ERROR = "NOTIFICATION_ERROR";
 
   @Override
   public String getName() {
@@ -51,7 +20,7 @@ public class NotificationManagerModule extends ReactContextBaseJavaModule {
       try {
         Boolean areEnabled = NotificationManagerCompat.from(getReactApplicationContext()).areNotificationsEnabled();
         promise.resolve(areEnabled);
-      }catch (Exception e) {
+      } catch (Exception e) {
         promise.reject(e.getMessage());
       }
   }

--- a/ios/CheckNotificationEnable.m
+++ b/ios/CheckNotificationEnable.m
@@ -57,4 +57,37 @@ RCT_EXPORT_METHOD(areNotificationsEnabled:(RCTPromiseResolveBlock)resolve reject
 	}
 }
 
+RCT_EXPORT_METHOD(retrieveGlobalNotificationSettings:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+	if (@available(iOS 10.0, *)) {
+		[[UNUserNotificationCenter currentNotificationCenter] getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
+			NSMutableDictionary *notificationSettings = [NSMutableDictionary dictionary];
+			[notificationSettings setValue:[NSNumber numberWithBool:mapAuthorizationStatus(settings.authorizationStatus)] forKey:@"isEnabled"];
+			[notificationSettings setValue:[NSNumber numberWithBool:mapNotificationSetting(settings.badgeSetting)] forKey:@"isBadgeEnabled"];
+			[notificationSettings setValue:[NSNumber numberWithBool:mapNotificationSetting(settings.soundSetting)] forKey:@"isSoundEnabled"];
+			[notificationSettings setValue:[NSNumber numberWithBool:mapNotificationSetting(settings.notificationCenterSetting)] forKey:@"shownInNotificationCenter"];
+			[notificationSettings setValue:[NSNumber numberWithBool:mapNotificationSetting(settings.lockScreenSetting)] forKey:@"shownInLockScreen"];
+			[notificationSettings setValue:[NSNumber numberWithBool:mapNotificationSetting(settings.alertSetting)] forKey:@"shownAsHeadsupDisplay"];
+			resolve(notificationSettings);
+		}];
+	} else {
+		// Fallback for iOS <10
+		BOOL remoteNotificationsEnabled = [UIApplication sharedApplication].isRegisteredForRemoteNotifications;
+		UIUserNotificationType userNotificationSettingsTypes = ([UIApplication sharedApplication].currentUserNotificationSettings).types;
+		NSMutableDictionary *notificationSettings = [NSMutableDictionary dictionary];
+		[notificationSettings setValue:[NSNumber numberWithBool:remoteNotificationsEnabled] forKey:@"isEnabled"];
+		[notificationSettings setValue:[NSNumber numberWithBool:(userNotificationSettingsTypes & UIUserNotificationTypeBadge) != 0] forKey:@"isBadgeEnabled"];
+		[notificationSettings setValue:[NSNumber numberWithBool:(userNotificationSettingsTypes & UIUserNotificationTypeSound) != 0] forKey:@"isSoundEnabled"];
+		[notificationSettings setValue:[NSNumber numberWithBool:TRUE] forKey:@"shownInNotificationCenter"];
+		[notificationSettings setValue:[NSNumber numberWithBool:TRUE] forKey:@"shownInLockScreen"];
+		[notificationSettings setValue:[NSNumber numberWithBool:(userNotificationSettingsTypes & UIUserNotificationTypeAlert) != 0] forKey:@"shownAsHeadsupDisplay"];
+		resolve(notificationSettings);
+	}
+
+}
+
+RCT_EXPORT_METHOD(retrieveNotificationChannels:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+	// iOS does not support notification channels
+	resolve([NSArray array]);
+}
+
 @end

--- a/react-native-check-notification-enable.d.ts
+++ b/react-native-check-notification-enable.d.ts
@@ -1,10 +1,21 @@
 declare module 'react-native-check-notification-enable' {
-  export interface NotificationManagerProps {
-    areNotificationsEnabled: () => Promise
+  interface NotificationSettings {
+    isEnabled: boolean;
+    isBadgeEnabled: boolean;
+    isSoundEnabled: boolean;
+    shownInNotificationCenter: boolean;
+    shownInLockScreen: boolean;
+    shownAsHeadsupDisplay: boolean;
+  }
+
+  interface NotificationChannel extends NotificationSettings {
+    id: string;
   }
 
   export const NotificationManager: {
-    areNotificationsEnabled: () => Promise
+    areNotificationsEnabled: () => Promise<boolean>,
+    retrieveGlobalNotificationSettings: () => Promise<NotificationSettings>,
+    retrieveNotificationChannels: () => Promise<NotificationChannel[]>,
   }
   export default NotificationManager
 }


### PR DESCRIPTION
This PR introduces 2 new functions: `retrieveGlobalNotificationSettings()` and `retrieveNotificationChannels()`.

These return a JS object (with the below shape) for the global notification settings and an object per notification channel (Android-only).

```typescript
interface NotificationSettings {
    isEnabled: boolean;
    isBadgeEnabled: boolean;
    isSoundEnabled: boolean;
    shownInNotificationCenter: boolean;
    shownInLockScreen: boolean;
    shownAsHeadsupDisplay: boolean;
}
```